### PR TITLE
Update TCheckbox.vue

### DIFF
--- a/src/elements/TCheckbox.vue
+++ b/src/elements/TCheckbox.vue
@@ -98,7 +98,9 @@ export default {
   watch: {
     indeterminate: {
       handler(indeterminate) {
-        this.setIndeterminate(indeterminate)
+        this.$nextTick(() => {
+          this.setIndeterminate(indeterminate)
+        })
       },
       immediate: true
     },


### PR DESCRIPTION
## Bug description 

For the following case the state of the checkbox is empty and not indeterminate:

```html
<t-checkbox
  v-model="model"
  :indeterminate="true"
/>
```

## Bug fix description 
Waiting DOM to be rendered in order to make the checkbox indeterminate when the indeterminate prop is set to true.