### PR TITLE
Fix modal scroll gap problem

### DIFF
--- a/src/components/TModal.vue
+++ b/src/components/TModal.vue
@@ -285,7 +285,9 @@ export default {
       this.$emit('closed');
     },
     prepareDomForModal() {
-      disableBodyScroll(this.$refs.modal);
+      disableBodyScroll(this.$refs.modal, {
+        reserveScrollBarGap: true,
+      });
       this.calculateMarginTop();
       if (this.$refs.modal) {
         this.$refs.modal.focus()


### PR DESCRIPTION
Fix modal scroll gap issue

if you have long page, and when modal opened, the scrollbar will be disabled, and missing the scroll bar width (padding-right) in body.

![demo](https://user-images.githubusercontent.com/5094008/75106241-3c2ccf80-5655-11ea-94dd-6665e7f47e12.gif)

