### PR TITLE
Remove event attribute for RouterLink / NuxtLink

### DIFF
--- a/src/elements/TButton.vue
+++ b/src/elements/TButton.vue
@@ -302,7 +302,6 @@ export default {
           tag: this.tagName,
           activeClass: this.activeClass,
           exact: this.exact,
-          event: ['click', 'focus', 'blur'],
           exactActiveClass: this.exactActiveClass,
           id: this.id,
           value: this.value,


### PR DESCRIPTION
In Nuxt.js this attribute cause asyncData to load multiple times.