### PR TITLE
Generate typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
     "*.json",
     "*.js"
   ],
+  "typings": "./dist/main.d.ts",
   "main": "./dist/vue-tailwind.umd.js"
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,27 @@
+/**
+ * These are some necessary steps changing the default webpack config of the Vue CLI
+ * that need to be changed in order for TypeScript based components to generate their
+ * declaration (.d.ts) files.
+ * Code by various users from https://github.com/vuejs/vue-cli/issues/1081
+ */
+const fixEmitDeclarationFilesForTypeScript = {
+  chainWebpack: config => {
+    if (process.env.NODE_ENV === "production") {
+      config.module.rule("ts").uses.delete("cache-loader");
+      config.module
+        .rule("ts")
+        .use("ts-loader")
+        .loader("ts-loader")
+        .tap(options => ({
+          ...options,
+          transpileOnly: false,
+          happyPackMode: false
+        }));
+    }
+  },
+  parallel: false
+};
+
+module.exports = {
+  ...fixEmitDeclarationFilesForTypeScript
+};


### PR DESCRIPTION
Typescript complains that there are no type declarations. This is an issue discussed in vuejs/vue-cli#1081.

I have added the code from that discussion, and a `typings` property to `package.json`.

This has been tested by:

1. Running `yarn build` in my local copy
2. Using in a project with `"vue-tailwind": "file:../vue-tailwind"`


