### PR TITLE
Move Vue to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "body-scroll-lock": "^3.0.3",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@tailwindcss/custom-forms": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "body-scroll-lock": "^3.0.3",
     "lodash": "^4.17.20",
-    "vue": "^2.6.11"
   },
   "devDependencies": {
     "@tailwindcss/custom-forms": "^0.2.1",
@@ -52,6 +51,7 @@
     "release-it": "^13.6.6",
     "tailwindcss": "^1.7.5",
     "typescript": "~3.9.7",
+    "vue": "^2.6.11",
     "vue-template-compiler": "^2.6.11"
   },
   "homepage": "https://vue-tailwind.com",


### PR DESCRIPTION
I am currently running into two issues that would be fixed by moving the Vue library to a dev dependency.

The first issue is that I cannot use a Vue version other than 2.6.11 provided with your library.

The second is when I specify and add the Vue to a dependency of my project, it loads two instances of the Vue runtime and then these errors are thrown:
https://stackoverflow.com/a/50932919