### PR TITLE
Added dropdown vertical overflow protection

### DIFF
--- a/src/components/TDropdown.ts
+++ b/src/components/TDropdown.ts
@@ -276,6 +276,23 @@ const TDropdown = Component.extend({
     },
     doShow() {
       this.localShow = true;
+
+      this.$nextTick(() => {
+        const dropdown = this.$refs.dropdown as HTMLDivElement;
+        const dropdownTop = dropdown.getBoundingClientRect().top;
+        const dropdownBounds = dropdownTop + dropdown.offsetHeight;
+
+        if (dropdownBounds > window.innerHeight && dropdownTop > dropdown.offsetHeight) {
+          const trigger = this.$el as HTMLDivElement;
+          const dropdownStyle = getComputedStyle(dropdown);
+          const offset = trigger.offsetHeight + dropdown.offsetHeight + parseFloat(dropdownStyle.marginTop);
+
+          Object.assign(dropdown.style, {
+            top: `-${offset}px`,
+            marginTop: '0px',
+          });
+        }
+      });
     },
     doToggle() {
       if (this.localShow) {


### PR DESCRIPTION
This PR adds vertical overflow protection for dropdowns.  

- It checks if space below dropdown's trigger is sufficient to display dropdown without creating overflow on viewport.
- If dropdown wouldn't be able to squeeze in it is offset by: `offsetHeight of dropdown + topMargin of dropdown + offsetHeight of trigger element`
- If space over trigger's element isn't sufficient either it falls back to default position.

It works for datepicker component too since under the hood it uses dropdown component.