### PR TITLE
Only make the date picker readonly while focused

### DIFF
--- a/src/components/TDatepicker.ts
+++ b/src/components/TDatepicker.ts
@@ -290,6 +290,7 @@ const TDatepicker = HtmlInput.extend({
       format,
       formatNative,
       currentLocale,
+      hasFocus: false,
     };
   },
 
@@ -614,9 +615,11 @@ const TDatepicker = HtmlInput.extend({
       }
     },
     focusHandler(e: FocusEvent) {
+      this.hasFocus = true;
       this.$emit('focus', e);
     },
     blurHandler(e: FocusEvent) {
+      this.hasFocus = false;
       this.$emit('blur', e);
     },
   },
@@ -681,6 +684,7 @@ const TDatepicker = HtmlInput.extend({
         locale: this.currentLocale,
         value: this.localValue,
         activeDate: this.activeDate,
+        hasFocus: this.hasFocus,
         getElementCssClass: this.getElementCssClass,
       },
       scopedSlots: this.$scopedSlots,

--- a/src/components/TDatepicker/TDatepickerTrigger.ts
+++ b/src/components/TDatepicker/TDatepickerTrigger.ts
@@ -88,6 +88,10 @@ const TDatepickerTrigger = Vue.extend({
       type: Function,
       required: true,
     },
+    hasFocus: {
+      type: Boolean,
+      required: true,
+    },
   },
 
   computed: {
@@ -124,7 +128,8 @@ const TDatepickerTrigger = Vue.extend({
           ref: 'input',
           class: this.getElementCssClass('input'),
           attrs: {
-            readonly: true,
+            // Prevents
+            readonly: !this.hasFocus ? this.readonly : true,
             id: this.id,
             name: this.name,
             disabled: this.disabled,
@@ -132,7 +137,7 @@ const TDatepickerTrigger = Vue.extend({
             autofocus: this.autofocus,
             type: 'text',
             required: this.required,
-            placeholder: this.placeholder,
+            placeholder: this.required ? 'reqired' : 'not-required',
             tabindex: this.tabindex,
             value: formText,
           },


### PR DESCRIPTION
Currently when the input is required is bein ignored by the built-in validation from the browser because the input is readonly, with this PR the input is only readonly while focused (to continue preventing user typing) and lost his readonly when lost focus so the validation works fine.

Closes https://github.com/alfonsobries/vue-tailwind/issues/143