### PR TITLE
Give the DatePicker back its original placeholder

### DIFF
--- a/src/components/TDatepicker/TDatepickerTrigger.ts
+++ b/src/components/TDatepicker/TDatepickerTrigger.ts
@@ -137,7 +137,7 @@ const TDatepickerTrigger = Vue.extend({
             autofocus: this.autofocus,
             type: 'text',
             required: this.required,
-            placeholder: this.required ? 'reqired' : 'not-required',
+            placeholder: this.placeholder,
             tabindex: this.tabindex,
             value: formText,
           },


### PR DESCRIPTION
Last version tag received this from debug driven development.
All jokes aside, here we give back the placeholder to any off your beloved TDatePicker component users, including me. :D