### PR TITLE
Fix multiselect tags not working when using fetchOptions

### DIFF
--- a/src/components/TRichSelect.ts
+++ b/src/components/TRichSelect.ts
@@ -359,6 +359,10 @@ const TRichSelect = MultipleInput.extend({
   methods: {
     // eslint-disable-next-line max-len
     findOptionByValue(value: string | number | boolean | symbol | null): undefined | NormalizedOption {
+      if (this.usesAJax) {
+        return this.filteredflattenedOptions
+          .find((option) => this.optionHasValue(option, value));
+      }
       return this.flattenedOptions
         .find((option) => this.optionHasValue(option, value));
     },


### PR DESCRIPTION
This PR fixes a bug which affects the TRichSelect component when using a combination of `multiple` and `fetchOptions`.

After hours of research, I have noticed that the `flattenedOptions property` was not getting populated when fetching options via Ajax. With the help of the condition check added, we can lookup the options from `filteredflattenedOptions` property instead.

Thank you for this awesome package  🤝