### PR TITLE
Fix TRichSelect not working when using fetchOptions in combination with multiple

### DIFF
--- a/src/components/TRichSelect.ts
+++ b/src/components/TRichSelect.ts
@@ -359,6 +359,10 @@ const TRichSelect = MultipleInput.extend({
   methods: {
     // eslint-disable-next-line max-len
     findOptionByValue(value: string | number | boolean | symbol | null): undefined | NormalizedOption {
+      if (this.usesAJax) {
+        return this.filteredflattenedOptions
+          .find((option) => this.optionHasValue(option, value));
+      }
       return this.flattenedOptions
         .find((option) => this.optionHasValue(option, value));
     },

--- a/src/components/TRichSelect.ts
+++ b/src/components/TRichSelect.ts
@@ -359,7 +359,7 @@ const TRichSelect = MultipleInput.extend({
   methods: {
     // eslint-disable-next-line max-len
     findOptionByValue(value: string | number | boolean | symbol | null): undefined | NormalizedOption {
-      if (this.usesAJax) {
+      if (this.usesAJax && this.selectedOptions.length > 0) {
         return this.selectedOptions
           .find((option) => this.optionHasValue(option, value));
       }

--- a/src/components/TRichSelect.ts
+++ b/src/components/TRichSelect.ts
@@ -360,7 +360,7 @@ const TRichSelect = MultipleInput.extend({
     // eslint-disable-next-line max-len
     findOptionByValue(value: string | number | boolean | symbol | null): undefined | NormalizedOption {
       if (this.usesAJax) {
-        return this.filteredflattenedOptions
+        return this.selectedOptions
           .find((option) => this.optionHasValue(option, value));
       }
       return this.flattenedOptions


### PR DESCRIPTION
This PR fixes a bug which affects the `TRichSelect` component when using a combination of `multiple` and `fetchOptions`.

After doing hours of research, I have noticed that the `flattenedOptions` property was not getting populated when fetching options via Ajax. With the help of the condition check added, we can lookup the options from the `selectedOptions` property instead of the empty `flattenedOptions` property.

Thank you for this awesome package 🤝