### PR TITLE
feat(modal): add body-scroll-lock-ignore class

### DIFF
--- a/src/components/TModal.ts
+++ b/src/components/TModal.ts
@@ -347,7 +347,17 @@ const TModal = Component.extend({
       }
 
       if (this.disableBodyScroll) {
-        disableBodyScroll(overlay);
+        disableBodyScroll(overlay, {
+          allowTouchMove: (el) => {
+            while (el && el !== document.body) {
+              if (el.getAttribute('body-scroll-lock-ignore') !== null) {
+                return true;
+              }
+
+              el = el.parentElement as HTMLElement | Element;
+            }
+          },
+        });
       }
 
       if (this.focusOnOpen) {


### PR DESCRIPTION
As per the notes on the body-scroll-lock package, https://www.npmjs.com/package/body-scroll-lock, when using this package on ios all children to the scrolled parent will not be scrollable, this is because the package removes any functionality on the `touchmove` events.

In the context of a modal, there is often a use case that on mobile we need the body of the modal to scroll using `overflow-y:scroll;`, or similar, this works in most browsers, but not ios safari. So, adding the allowTouchMove callback will mean that scroll can be enabled for selected children