### PR TITLE
fix(TCheckbox): fix reversed checkbox state when using `checked` prop

### DIFF
--- a/src/inputs/TCheckbox.ts
+++ b/src/inputs/TCheckbox.ts
@@ -236,9 +236,7 @@ const TCheckbox = HtmlInput.extend({
     setChecked(checked: boolean) {
       const input = this.getInput();
 
-      // this.localValue = checked;
-      input.checked = !checked;
-      input.click();
+      input.checked = checked;
 
       // Emit update event to prop
       this.$emit('update:checked', checked);


### PR DESCRIPTION
@alfonsobries Could you please review this minor change and accept this PR if all looks okay?

When checkbox is controlled only with `checked` prop (instead of using `v-model`), the input's `checked` value was set incorrectly (reversed). This PR fixes it for me and now checkboxes work like a charm.