### PR TITLE
Renamed navigatorViewButtonMonthName to navigatorViewButtonMonth

### DIFF
--- a/src/components/TDatepicker/TDatepickerNavigator.ts
+++ b/src/components/TDatepicker/TDatepickerNavigator.ts
@@ -372,7 +372,7 @@ const TDatepickerNavigator = Vue.extend({
           createElement(
             'span',
             {
-              class: this.getElementCssClass('navigatorViewButtonMonthName'),
+              class: this.getElementCssClass('navigatorViewButtonMonth'),
             },
             this.formatNative(this.localValue, 'F'),
           ),


### PR DESCRIPTION
Component: Datepicker
Wrong class name for `View toggler month text`.

Renamed `navigatorViewButtonMonthName` to `navigatorViewButtonMonth` as documented. 