### PR TITLE
Added check if ref exists before calling it

### DIFF
--- a/src/components/TDatepicker.ts
+++ b/src/components/TDatepicker.ts
@@ -570,7 +570,7 @@ const TDatepicker = HtmlInput.extend({
         focus: () => void
       };
 
-      (this.$refs.timePicker as TimePicker).focus();
+      (this.$refs.timePicker as TimePicker)?.focus();
     },
     inputDateHandler(date: Date): void {
       this.dateWithoutTime = date;


### PR DESCRIPTION
Component: datepicker

**Bug**: while drop down menu is open and by clicking num pad numbers component tries to focus time input field but $ref to time input field is never created.
```
<t-datepicker
      variant="custom"
      :timepicker="false"
  />
```

Errors:
![firefox_6zHKOBCN1F](https://user-images.githubusercontent.com/35690113/145838940-89ede58e-7b3b-4044-b269-39761a11004e.png)

